### PR TITLE
Add Kalman Smoothing derivatives

### DIFF
--- a/derivative/dglobal.py
+++ b/derivative/dglobal.py
@@ -3,7 +3,8 @@ from .utils import deriv, integ
 
 import numpy as np
 from numpy.linalg import inv
-from scipy import interpolate
+from scipy import interpolate, sparse
+from scipy.sparse import linalg as splinalg
 from scipy.special import legendre
 from sklearn.linear_model import Lasso
 
@@ -174,3 +175,63 @@ class TrendFiltered(Derivative):
         self._global(t, x)
         for i in indices:
             yield self._res[i]
+
+
+@register("kalman")
+class Kalman(Derivative):
+    def __init__(self, alpha = 1):
+        """ Fit the derivative assuming that given data are noisy measurements
+
+        The Kalman Smoother is the maximum likelihood estimator for a coordinate whose derivative obeys Brownian
+        motion and whose measurement errors are unbiased and identical normal distributions.  It minimizes the
+        convex objective:fn_str
+
+        .. math ::
+            \min_{x, \dot x} \|Hx-z\|_{R^{-1}}^2 + \alpha \|G(x, \dot x)\|_{Q^{-1}}^2
+
+        This implementation only allows H = R = I.  Q is the matrix:
+
+        .. math ::
+            \left[\begin{matix}\Delta t & \Delta t^2/2\\ \Delta t^2/2 & \Delta t^3/3\end{matrix}\right]
+
+        Args:
+            alpha (float): Ratio of measurement error variance to assumed process variance.
+        """
+        self._t = None
+        self._x = None
+        self._xdot_hat = None
+        self._x_hat = None
+        self.alpha = alpha
+
+
+    def _global(self, t, x, alpha):
+        self._t = t
+        self._x = x
+        delta_times = t[1:]-t[:-1]
+        n = len(t)
+        Qs = [np.array([[dt, dt**2/2], [dt**2/2, dt**3/3]]) for dt in delta_times]
+        Qinv = alpha*sparse.block_diag([np.linalg.inv(Q) for Q in Qs])
+        Qinv = (Qinv + Qinv.T)/2  # force to be symmetric
+
+        G_left = sparse.block_diag([-np.array([[1, 0], [dt, 1]]) for dt in delta_times])
+        G_right = sparse.eye(2*(n-1))
+        align_cols = sparse.csc_matrix((2 * (n-1), 2))
+        G = sparse.hstack((G_left, align_cols)) + sparse.hstack((align_cols, G_right))
+
+        H = sparse.lil_matrix((n, 2*n))
+        H[:, 1::2] = sparse.eye(n)
+
+        A = sparse.vstack((H, G.T @ Qinv @ G))
+        b = np.vstack((x.reshape((-1,1)), np.zeros((2*n, 1))))
+        sol = np.linalg.solve((A.T @ A).todense(), A.T @ b)
+        self._x_hat = H @ sol
+        self._xdot_hat = H[:, list(range(1,2*n))+ [0]] @ sol
+
+    def compute(self, t, x, i):
+        self._global(t, x, self.alpha)
+        return self._xdot_hat[i]
+
+    def compute_for(self, t, x, indices):
+        self._global(t, x, self.alpha)
+        for i in indices:
+            yield self._xdot_hat[i]

--- a/derivative/dglobal.py
+++ b/derivative/dglobal.py
@@ -224,8 +224,8 @@ class Kalman(Derivative):
         A = sparse.vstack((H, G.T @ Qinv @ G))
         b = np.vstack((x.reshape((-1,1)), np.zeros((2*n, 1))))
         sol = np.linalg.solve((A.T @ A).todense(), A.T @ b)
-        self._x_hat = H @ sol
-        self._xdot_hat = H[:, list(range(1,2*n))+ [0]] @ sol
+        self._x_hat = (H @ sol).flatten()
+        self._xdot_hat = (H[:, list(range(1,2*n))+ [0]] @ sol).flatten()
 
     def compute(self, t, x, i):
         self._global(t, x, self.alpha)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -19,6 +19,8 @@ def default_args(kind):
         return {'k': 1}
     elif kind == 'savitzky_golay':
         return {'left': 5, 'right': 5, 'order': 3, 'iwindow': True}
+    elif kind == 'kalman':
+        return {'alpha': .05}
     else:
         raise ValueError('Unimplemented default args for kind {}.'.format(kind))
 


### PR DESCRIPTION
I added a kalman smoothing global derivative method.  Example:
```python
import numpy as np
from matplotlib import pyplot as plt
from derivative import dxdt
t = np.arange(0,2*np.pi, .05)
x = np.sin(t) + .1 * np.random.randn(*t.shape)
xdot_hat = dxdt(x, t, kind="kalman", alpha=1)
print(np.max(xdot_hat-np.cos(t)))
plt.plot(t, np.cos(t), "b-", label="true derivatives")
plt.plot(t, xdot_hat, "bx", label="smoothed derivatives")
plt.plot(t,x, 'gx', label="noisy measurements")
plt.plot(t, np.sin(t), 'g-', label='true values')
plt.legend()
```
![kalman example](https://user-images.githubusercontent.com/37048747/168187227-f7084653-fad6-4443-866d-203bbe0cb8bd.png)




Passes all tests, but I can't build the docs.  I get:
```
Running Sphinx v3.5.4
WARNING: html_static_path entry '_static' does not exist
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 5 source files that are out of date
updating environment: [new config] 5 added, 0 changed, 0 removed
reading sources... [100%] notebooks/Examples                                                         
Notebook error:
PandocMissing in notebooks/Examples.ipynb:
Pandoc wasn't found.
Please check that pandoc is installed:
https://pandoc.org/installing.html
make: *** [Makefile:20: html] Error 2
```
Is pandoc missing from pyproject.toml?  Working on that now.