### PR TITLE
BLD: Update build backend to allow editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,5 +33,5 @@ docs = ["sphinx", "nbsphinx", "ipykernel", "jupyter_client", "sphinx_rtd_theme",
 dev = ["pytest"]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This allows editable installs of packages without a setup.py, a la
```
pip install -e derivative
```

PEP-660 supported by poetry.core ~=1.0.0.  Following recommendation
in
https://github.com/python-poetry/poetry/issues/2956#issuecomment-1002746798
and
https://python-poetry.org/docs/faq/#is-tox-supported