### PR TITLE
Allow calculation of smoothed x values, preventing recomputation

### DIFF
--- a/derivative/__init__.py
+++ b/derivative/__init__.py
@@ -1,4 +1,4 @@
-from .differentiation import dxdt, methods
+from .differentiation import dxdt, smooth_x, methods
 from .dglobal import Spectral, Spline, TrendFiltered, Kalman
 from .dlocal import FiniteDifference, SavitzkyGolay
 

--- a/derivative/dglobal.py
+++ b/derivative/dglobal.py
@@ -240,17 +240,11 @@ class Kalman(Derivative):
         for i in indices:
             yield self._xdot_hat[i]
 
-    def x(self, X, t, axis=1):
-        """
-        Compute the smoothed X values from measurements X taken at times t.
+    def compute_x(self, t, x, i):
+        self._global(t, x, self.alpha)
+        return self._x_hat[i]
 
-        Args:
-            X  (:obj:`ndarray` of float): Ordered measurements values. Multiple measurements allowed.
-            t (:obj:`ndarray` of float): Ordered measurement times.
-            axis ({0,1}). axis of X along which to smooth. default 1.
-
-        Returns:
-            :obj:`ndarray` of float: Returns dX/dt along axis.
-        """
-        self._global(t, X, self.alpha)
-        return self._x_hat
+    def compute_x_for(self, t, x, indices):
+        self._global(t, x, self.alpha)
+        for i in indices:
+            yield self._x_hat[i]

--- a/derivative/differentiation.py
+++ b/derivative/differentiation.py
@@ -191,13 +191,8 @@ class Derivative(abc.ABC):
         Raises:
             ValueError: Requires that X.shape[axis] equals len(t). If X is flat, requires that len(X) equals len(t).
         """
-        # Cast
-        X = np.array(X)
-        if not X.size:
-            return np.array([])
         X, flat = _align_axes(X, t, axis)
 
-        # Differentiate if 2 or more points along axis
         if X.shape[1] == 1:
             dX = X
         else:
@@ -221,12 +216,8 @@ class Derivative(abc.ABC):
         Returns:
             :obj:`ndarray` of float: Returns dX/dt along axis.
         """
-        X = np.array(X)
-        if not X.size:
-            return np.array([])
         X, flat = _align_axes(X, t, axis)
 
-        # Differentiate if 2 or more points along axis
         if X.shape[1] == 1:
             dX = X
         else:
@@ -236,6 +227,8 @@ class Derivative(abc.ABC):
 
 
 def _align_axes(X, t, axis):
+    # Cast
+    X = np.array(X)
     flat = False
     # Check shape and axis
     if len(X.shape) == 1:

--- a/derivative/differentiation.py
+++ b/derivative/differentiation.py
@@ -1,6 +1,7 @@
 import abc
 import numpy as np
 
+from .utils import _memoize_arrays
 
 methods = {}
 default = ["finite_difference", {"k": 1}]
@@ -12,6 +13,11 @@ def register(name=""):
         methods[n] = f
         return f
     return inner
+
+
+@_memoize_arrays()
+def _gen_method(x, t, kind, axis, **kwargs):
+    return methods.get(kind)(**kwargs)
 
 
 def dxdt(x, t, kind=None, axis=1, **kwargs):
@@ -42,11 +48,11 @@ def dxdt(x, t, kind=None, axis=1, **kwargs):
         :obj:`ndarray` of float: Returns dx/dt along axis.
     """
     if kind is None:
-        method = methods.get(default[0])
-        return method(**default[1]).d(x, t, axis=axis)
+        method = _gen_method(x, t, default[0], axis, **default[1])
+        return method.d(x, t, axis=axis)
     else:
-        method = methods.get(kind)
-        return method(**kwargs).d(x, t, axis=axis)
+        method = _gen_method(x, t, kind, axis, **kwargs)
+        return method.d(x, t, axis=axis)
 
 
 class Derivative(abc.ABC):

--- a/derivative/differentiation.py
+++ b/derivative/differentiation.py
@@ -156,24 +156,7 @@ class Derivative(abc.ABC):
         X = np.array(X)
         if not X.size:
             return np.array([])
-
-        flat = False
-        # Check shape and axis
-        if len(X.shape) == 1:
-            X = X.reshape(1, -1)
-            flat = True
-        elif len(X.shape) == 2:
-            if axis == 0:
-                X = X.T
-            elif axis == 1:
-                pass
-            else:
-                raise ValueError("Invalid axis.")
-        else:
-            raise ValueError("Invalid shape of X.")
-
-        if X.shape[1] != len(t):
-            raise ValueError("Desired X axis size does not match t size.")
+        X, flat = _align_axes(X, t, axis)
 
         # Differentiate if 2 or more points along axis
         if X.shape[1] == 1:
@@ -181,10 +164,7 @@ class Derivative(abc.ABC):
         else:
             dX = np.array([list(self.compute_for(t, x, np.arange(len(t)))) for x in X])
 
-        if flat:
-            return dX.flatten()
-        else:
-            return dX if axis == 1 else dX.T
+        return _restore_axes(dX, axis, flat)
 
 
     def x(self, X, t, axis=1):
@@ -203,3 +183,31 @@ class Derivative(abc.ABC):
             :obj:`ndarray` of float: Returns dX/dt along axis.
         """
         return X
+
+
+def _align_axes(X, t, axis):
+    flat = False
+    # Check shape and axis
+    if len(X.shape) == 1:
+        X = X.reshape(1, -1)
+        flat = True
+    elif len(X.shape) == 2:
+        if axis == 0:
+            X = X.T
+        elif axis == 1:
+            pass
+        else:
+            raise ValueError("Invalid axis.")
+    else:
+        raise ValueError("Invalid shape of X.")
+
+    if X.shape[1] != len(t):
+        raise ValueError("Desired X axis size does not match t size.")
+    return X, flat
+
+
+def _restore_axes(dX, axis, flat):
+    if flat:
+        return dX.flatten()
+    else:
+        return dX if axis == 1 else dX.T

--- a/derivative/utils.py
+++ b/derivative/utils.py
@@ -57,7 +57,7 @@ def integ(n, dx=1):
         raise ValueError('Bad size of {}'.format(n))
 
 
-def _memoize_arrays(maxsize=1):
+def _memoize_arrays(maxsize=128):
     """A cache wrapper for functions that accept numpy arrays.
 
     Cannot directly use any memoization from functools on these

--- a/derivative/utils.py
+++ b/derivative/utils.py
@@ -1,3 +1,5 @@
+from functools import _CacheInfo as CacheInfo, wraps
+from collections import OrderedDict, Counter
 import numpy as np
 from scipy.special import binom
 
@@ -53,3 +55,75 @@ def integ(n, dx=1):
         return np.array(M) * dx / 2
     else:
         raise ValueError('Bad size of {}'.format(n))
+
+
+def _memoize_arrays(maxsize=1):
+    """A cache wrapper for functions that accept numpy arrays.
+
+    Cannot directly use any memoization from functools on these
+    functions because they require hashable types.
+    """
+    def memoizing_decorator(wrapped_func):
+        class ArrayKey(int):
+            pass
+
+        def make_key(*args, **kwargs):
+            def arrs_to_keys(*args, **kwargs):
+                new_args = []
+                new_kwargs = {}
+                for arg in args:
+                    if not isinstance(arg, np.ndarray):
+                        new_args.append(arg)
+                        continue
+                    key = ArrayKey(hash(arg.tobytes()))
+                    new_args.append(key)
+                for k, v in kwargs.items():
+                    if not isinstance(v, np.ndarray):
+                        new_kwargs[k] = v
+                        continue
+                    key = ArrayKey(hash(v.tobytes()))
+                    new_kwargs[k] = key
+                return new_args, new_kwargs
+            new_args, new_kwargs = arrs_to_keys(*args, **kwargs)
+            new_args_dict = {k: v for k, v in enumerate(new_args)}
+            return (
+                        tuple(sorted(new_args_dict.items()))
+                        + tuple(sorted(new_kwargs.items()))
+                    )
+
+        arg_dict = OrderedDict()
+        hits = 0
+        misses = 0
+        @wraps(wrapped_func)
+        def wrapper_func(*args, **kwargs):
+            nonlocal arg_dict, hits, misses
+            cache_key = make_key(*args, **kwargs)
+            try:
+                result = arg_dict[cache_key]
+                arg_dict.move_to_end(cache_key)
+                hits += 1
+                return result
+            except KeyError: pass
+            misses += 1
+            result = wrapped_func(*args, **kwargs)
+            if maxsize > 0:
+                arg_dict[cache_key] = result
+                if len(arg_dict) > maxsize:
+                    arg_dict.popitem(last=False)
+            return result
+
+        def cache_clear():
+            nonlocal arg_dict, hits, misses
+            arg_dict = OrderedDict()
+            hits = 0
+            misses = 0
+        wrapper_func.cache_clear = cache_clear
+
+        def cache_info():
+            return CacheInfo(hits, misses, maxsize, arg_dict.__len__())
+        wrapper_func.cache_info = cache_info
+
+        return wrapper_func
+
+    return memoizing_decorator
+

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -175,3 +175,11 @@ def test_kalman_dglobal_caching(kalman_method):
     assert method._global.cache_info().hits == 1
     assert method._global.cache_info().misses == 1
     assert method._global.cache_info().currsize == 1
+
+
+def test_cached_kalman_global_order(kalman_method):
+    x, t, method = kalman_method
+    x = np.vstack((x, -x))
+    first_result = method.x(x, t)
+    second_result = method.x(x, t)
+    np.testing.assert_equal(first_result, second_result)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -38,12 +38,6 @@ def test_axis():
 
 def test_empty():
     empty = np.array([])
-    # spectral
-    assert 0 == dxdt(empty, empty, kind='spectral').size
-    # spline
-    assert 0 == dxdt(empty, empty, kind='spline', order=1, s=.01).size
-    # trend_filtered
-    assert 0 == dxdt(empty, empty, kind='trend_filtered', order=1, alpha=.01, max_iter=1e3).size
     # finite_difference
     assert 0 == dxdt(empty, empty, kind='finite_difference', k=1).size
     # savitzky_golay

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,7 +77,7 @@ def test_integ_dx():
 
 def test_memoize_arrays():
     arr = np.array([1,2,3])
-    @_memoize_arrays()
+    @_memoize_arrays(maxsize=1)
     def sin(arr, addendum):
         return np.sin(arr) + addendum
     result = sin(arr, 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 # Run tests on utils.py methods
-from derivative.utils import deriv, integ
+from derivative.utils import deriv, integ, _memoize_arrays
 import pytest
 import numpy as np
 
@@ -75,3 +75,54 @@ def test_integ_dx():
     assert np.all(np.isclose(result, expect))
 
 
+def test_memoize_arrays():
+    arr = np.array([1,2,3])
+    @_memoize_arrays()
+    def sin(arr, addendum):
+        return np.sin(arr) + addendum
+    result = sin(arr, 1)
+    sin(arr, 1)
+    sin(2* arr, 1)
+    assert sin.cache_info().hits == 1
+    assert sin.cache_info().misses == 2
+    assert sin.cache_info().currsize == 1
+    np.testing.assert_almost_equal(result, np.sin(arr)+1)
+
+
+def test_memoize_array_cachesize_zero():
+    arr = np.array([1,2,3])
+
+    @_memoize_arrays(maxsize=0)
+    def sin(arr, addendum):
+        return np.sin(arr) + addendum
+
+    sin(arr, 1)
+    sin(arr, 1)
+    assert sin.cache_info().hits == 0
+    assert sin.cache_info().misses == 2
+    assert sin.cache_info().currsize == 0
+
+def test_memoize_array_clear_cache():
+    arr = np.array([1,2,3])
+
+    @_memoize_arrays(maxsize=1)
+    def sin(arr, addendum):
+        return np.sin(arr) + addendum
+
+    sin(arr, 1)
+    sin.cache_clear()
+    assert sin.cache_info().misses == 0
+    assert sin.cache_info().currsize == 0
+
+def test_memoize_array_kwargs():
+    arr = np.array([1,2,3])
+
+    @_memoize_arrays(maxsize=1)
+    def sin(arr, addendum=1):
+        return np.sin(arr) + addendum
+
+    sin(arr, addendum=1)
+    sin(arr, addendum=1)
+    assert sin.cache_info().hits == 1
+    assert sin.cache_info().misses == 1
+    assert sin.cache_info().currsize == 1


### PR DESCRIPTION
As discussed in #13 , this implements fully backwards-compatible functional and object-oriented interfaces to calculate smoothed x values.  Only implemented for Kalman, but extremely easy for other global methods, and pretty easy for local methods that smooth.  The key innovation here is the `@_memoize_arrays` decorator, which prevents expensive recomputations for functions with array arguments (numpy arrays, being unhashable, prevent using `@functools.lru_cache`)

- On the functional side, create memoized `_gen_method()` function to allow reusing `Derivative` objects between `dxdt()` and new `smooth_x` functions.
- On the object-oriented side, memoize `Kalman._global()` and add a `Derivative.x()` method

Added tests for all the memoization issues (e.g. memory leaks), as well as `smooth_x` and the Kalman business.