### PR TITLE
Kalman typo

### DIFF
--- a/derivative/__version__.py
+++ b/derivative/__version__.py
@@ -1,1 +1,1 @@
-__version__: str = '0.5.1'
+__version__: str = '0.5.2'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "derivative"
-version = "0.5.1"
+version = "0.5.2"
 description = "Numerical differentiation in python."
 repository = "https://github.com/andgoldschmidt/derivative"
 documentation = "https://derivative.readthedocs.io/"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -15,7 +15,7 @@ def default_args(kind):
     elif kind == 'spline':
         return {'s': 0.1}
     elif kind == 'trend_filtered':
-        return {'order': 0, 'alpha': .01, 'max_iter': 1e3}
+        return {'order': 0, 'alpha': .01, 'max_iter': int(1e3)}
     elif kind == 'finite_difference':
         return {'k': 1}
     elif kind == 'savitzky_golay':

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -111,8 +111,9 @@ def test_fn(m, func_spec):
 
 def test_smoothing_x():
     t = np.linspace(0, 1, 100)
-    x = np.sin(t) + np.random.normal(size=t.shape)
-    method = _gen_method(x, t, kind="kalman", axis=1, alpha=1.0)
+    rng = np.random.default_rng(10)
+    x = np.sin(t) + rng.normal(size=t.shape)
+    method = _gen_method(x, t, kind="kalman", axis=1, alpha=135)
     x_est = method.x(x, t)
     # MSE
     assert np.linalg.norm(x_est - np.sin(t)) ** 2 / len(t) < 1e-1
@@ -120,8 +121,9 @@ def test_smoothing_x():
 
 def test_smoothing_functional():
     t = np.linspace(0, 1, 100)
-    x = np.sin(t) + np.random.normal(size=t.shape)
-    x_est = smooth_x(x, t, kind="kalman", axis=1, alpha=1.0)
+    rng = np.random.default_rng(10)
+    x = np.sin(t) + rng.normal(size=t.shape)
+    x_est = smooth_x(x, t, kind="kalman", axis=1, alpha=135)
     # MSE
     assert np.linalg.norm(x_est - np.sin(t)) ** 2 / len(t) < 1e-1
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -75,7 +75,7 @@ def test_small():
     assert three.shape == dxdt(three, three, kind='spline', **kwargs).shape
 
     # trend_filtered - ValueError: Requires that the number of points n > order + 1 to compute the objective
-    kwargs = {'order': 1, 'alpha': .01, 'max_iter': 1e3}
+    kwargs = {'order': 1, 'alpha': .01, 'max_iter': int(1e3)}
     with pytest.raises(ValueError):
         dxdt(two, two, kind='trend_filtered', **kwargs)
     assert three.shape == dxdt(three, three, kind='trend_filtered', **kwargs).shape


### PR DESCRIPTION
I messed up a bit when coding Kalman the first time.  This fixes that error, makes the tests more repeatable (for troubleshooting things like this), and fixes a bug where sklearn ~= 1.1 requires `max_iter` to be an `int`, not a `float`.  And bumps the version.