### PR TITLE
Upgrade dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.rst"
 python = "^3.7"
 numpy = "^1.18.3"
 scipy = "^1.4.1"
-scikit-learn = "~1.0.0"
+scikit-learn = "^1"
 
 # docs
 sphinx = {version = "^4.0.2", optional = true}
@@ -26,7 +26,7 @@ matplotlib = {version = "^3.2.1", optional = true}
 pandoc = {version = "^2.2", optional = true}
 
 # dev
-pytest = {version = "^3.6.4", optional = true}
+pytest = {version = "^7", optional = true}
 
 [tool.poetry.extras]
 docs = ["sphinx", "nbsphinx", "ipykernel", "jupyter_client", "sphinx_rtd_theme", "matplotlib", "pandoc"]


### PR DESCRIPTION
Hey Andy, I had a bit of laptop-repair musical chairs recently, which led me to discover some version issues in the dependencies.  Are you ok with these changes?


- Python 3.10 needs pytest >= 6.2.4, but dev requirement currently <3.7. Version 7.2.2 most recent.
- scikit-learn needs >=1.1.0 or it raises warnings in recent scipy versions, but requirement currently set at <1.1.  Version 1.2.2 most recent.

Tests all pass with pytest 7.0.0, scikit-learn 1.1.0 as well as most recent pytest 7.2.2, scikit-learn 1.2.2.