### PR TITLE
ENH: Add Kernel Smoothing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+todo
+commit-msg
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -74,6 +77,9 @@ target/
 
 # PyCharm folder
 .idea/
+
+# VSCode folder
+.vscode/
 
 # OSX 
 .DS_Store

--- a/derivative/__init__.py
+++ b/derivative/__init__.py
@@ -1,5 +1,5 @@
 from .differentiation import dxdt, smooth_x, methods
-from .dglobal import Spectral, Spline, TrendFiltered, Kalman
+from .dglobal import Spectral, Spline, TrendFiltered, Kalman, Kernel
 from .dlocal import FiniteDifference, SavitzkyGolay
 
 from .__version__ import __version__

--- a/derivative/dglobal.py
+++ b/derivative/dglobal.py
@@ -260,18 +260,6 @@ class Kernel(Derivative):
     def __init__(self, sigma: float=1, lmbd: float=0, kernel: str="gaussian"):
         """ Fit the derivative assuming a gaussian process specified by kernels
 
-        .. math ::
-            T = [t_1, \\dots, t_n]
-            K(T, T) = \\left[\\begin{matrix}
-                k(t_1,t_1) & \dots & k(t_1, t_n)\\\\
-                \vdots & \\ddots & \\vdots
-                k(t_n,t_1) & \dots & k(t_n, t_n)\\\\
-            \\end{matrix}\\right]
-            x(t) = K(t, T)(K(T, T) + \\sigma I)^{-1}z
-            \\dot x(t) = K_t(t, T)(K(T, T) + \\sigma I)^{-1}z
-
-        Where z are measurements.
-
         Args:
             sigma: parameter of kernel function
             lmbd: noise variance

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'nbsphinx'
               ]
-
+nbsphinx_execute = 'never'
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,9 @@ Numerical differentiation methods for noisy time series data in python includes:
     # 6. Kalman derivative with smoothing set to 1
     result6 = dxdt(x, t, kind="kalman", alpha=1)
 
+    # 7. Kernel derivative with smoothing set to 1
+    result7 = dxdt(x, t, kind="kernel", sigma=1, lmbd=.1, kernel="rbf")
+
 
 1. Symmetric finite difference schemes using arbitrary window size.
 
@@ -63,6 +66,8 @@ Numerical differentiation methods for noisy time series data in python includes:
 5. Polynomial-trend-filtered derivatives generalizing methods like total variational derivatives.
 
 6. Kalman derivatives find the maximum likelihood estimator for a derivative described by a Brownian motion.
+
+7. Kernel derivatives smooth a random process defined by its kernel (covariance).
 
 The goal of this package is to provide some common numerical differentiation techniques that showcase improvements that can be made on finite differences when data is noisy. 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,7 @@ References:
 
 [3] The Solution Path of the Generalized LASSO- R.J. Tibshirani and J. Taylor
 
+[4] A Kernel Approach for PDE Discovery and Operator Learning - D. Long et al.
 
 Indices and tables
 ==================

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -42,6 +42,11 @@ Kalman
 
     .. autofunction:: derivative.dglobal.Kalman.__init__
 
+Kernel
+^^^^^^
+
+    .. autofunction:: derivative.dglobal.Kernel.__init__
+
 |
 |
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -22,6 +22,8 @@ def default_args(kind):
         return {'left': 5, 'right': 5, 'order': 3, 'iwindow': True}
     elif kind == 'kalman':
         return {'alpha': .05}
+    elif kind == "kernel":
+        return {"sigma": 1, "lmbd": .01, "kernel": "gaussian"}
     else:
         raise ValueError('Unimplemented default args for kind {}.'.format(kind))
 


### PR DESCRIPTION
Hey Andy, added a new derivative method: kernel smoothing.

This is a much simpler, more limited implementation of smoothing using a radial basis function kernel than Bamdad and Juan, et al put in their paper.  In particular, it only includes the rbf kernel and doesn't include the JAX optimizations (which will add another level of dependency sophistication, if it comes to that).  However, it passes the numerical tests and will allow adding additional kernels with time.

@bamdadhosseini @jfelipeosorio could you point me to the paper so that we can add a citation?  And check if the docstring is how it should look?

Doc build:
- I also added to the build config to _not_ re-run the example jupyter notebook when building docs.  It was causing an error that RTFD ignores.
- Doc build passes on my PC, but doesn't include the docstring for the Kernel Smoother.  We can leave this PR open until I can figure that out, or open an issue and follow it up at a later date.  FWIW, index.rst does add documentation of kernel derivatives.  saving the build log here so I can read it later.
[build.log](https://github.com/andgoldschmidt/derivative/files/11368905/build.log)
