### PR TITLE
GitHub Action - Release

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7"]
-        poetry-version: ["1.2.0"]
+        poetry-version: ["1.2.1"]
 
     steps:
       # ======
@@ -23,7 +23,14 @@ jobs:
       # ======
       # Install and configure poetry
       # ======
+      - name: Load cached Poetry installation
+        id: cached-poetry
+        uses: actions/cache@v3
+        with:
+          path: ~/.local  # the path depends on the OS
+          key: poetry-${{ matrix.poetry-version }}
       - name: Install Poetry
+        if: steps.cached-poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
         with:
           version: ${{ matrix.poetry-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release:
+    name: Deploy release to Test-PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+    strategy:
+      matrix:
+        python-version: ["3.7"]
+        poetry-version: ["1.2.1"]
+    steps:
+      # ======
+      # Checkout, set up python
+      # ======
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      # ======
+      # Install poetry
+      # ======
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: ${{ matrix.poetry-version }}
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+      # ======
+      # Install dependencies
+      # ======
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+      # ======
+      # Build and upload package to Test-PyPI
+      # Null API token? "There is no pypi-token.testpypi setting."
+      # =====
+      - name: Upload package
+        run: |
+          poetry config repositories.testpypi https://test.pypi.org/legacy/
+          poetry config pypi-token.testpypi ${{ secrets.TEST_PYPI_TOKEN }}
+          poetry publish --no-interaction --build -r testpypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,8 @@ jobs:
     name: Deploy release to Test-PyPI
     runs-on: ubuntu-latest
     environment:
-      name: testpypi
+#      name: testpypi
+      name: release
     strategy:
       matrix:
         python-version: ["3.7"]
@@ -42,9 +43,12 @@ jobs:
       # ======
       # Build and upload package to Test-PyPI
       # Null API token? "There is no pypi-token.testpypi setting."
+      # Test?
+      #  poetry config repositories.testpypi https://test.pypi.org/legacy/
+      #  poetry config pypi-token.testpypi ${{ secrets.TEST_PYPI_TOKEN }}
+      #  poetry publish --no-interaction --build -r testpypi
       # =====
       - name: Upload package
         run: |
-          poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry config pypi-token.testpypi ${{ secrets.TEST_PYPI_TOKEN }}
-          poetry publish --no-interaction --build -r testpypi
+          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+          poetry publish --no-interaction --build


### PR DESCRIPTION
Add continuous deployment as PyPI release after `release: types: - publish` trigger

closes #29 