### PR TITLE
Differentiate any axis, not just 0 or 1

### DIFF
--- a/.github/workflows/pull-docs.yml
+++ b/.github/workflows/pull-docs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7" ]
+        python-version: [ "3.9" ]
         poetry-version: [ "1.2.1" ]
     steps:
       # ======

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.9"]
         poetry-version: ["1.2.1"]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       name: release
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.9"]
         poetry-version: ["1.2.1"]
     steps:
       # ======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.rst"
 
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.9"
 numpy = "^1.18.3"
 scipy = "^1.4.1"
 scikit-learn = "^1"

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -33,6 +33,10 @@ def test_axis():
     shape2 = ts.shape
     test3 = dxdt(ts, ts, axis=1).shape
     assert shape2 == test3
+    n = 4
+    x3d = np.tile(np.arange(n), (n, n, 1))
+    test_4 = dxdt(x3d, np.arange(n), axis=2)
+    np.testing.assert_array_equal(test_4, np.ones((n,n,n)))
 
 
 def test_empty():


### PR DESCRIPTION
Hey andy, this PR fixes #40.  Implemented via `_align_axes()` and `_restore_axes()`, as suggested.  Added a 3D version to the shape test.