### PR TITLE
CI: In doc build, install poetry if no cache hit

### DIFF
--- a/.github/workflows/pull-docs.yml
+++ b/.github/workflows/pull-docs.yml
@@ -28,6 +28,13 @@ jobs:
         with:
           path: ~/.local  # the path depends on the OS
           key: poetry-${{ matrix.poetry-version }}
+      - name: Install poetry
+        if: steps.cached-poetry.outputs.cache-hit != 'true'
+        uses: snok/install-poetry@v1
+        with:
+          version: ${{ matrix.poetry-version }}
+          virtualenvs-create: true
+          virtualenvs-in-project: true
       # ======
       # Load cached venv if cache exists
       # Install dependencies if cache does not exist


### PR DESCRIPTION
push-test.yml has a step to install poetry if no cached environment exists.  pull-docs.yml does not, and so the poetry command to install dependencies was giving `poetry: command not found` and killing the workflow.  Previous workflow successes all loaded the cached poetry installation.  I don't know where the cache entry was added, but it must have expired at some point in the last month.

This adds the install poetry step to pull-docs.yml