### PR TITLE
CI: Add Benchmarking

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -73,6 +73,8 @@ jobs:
       # ======
       - name: Check out
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -120,3 +120,9 @@ jobs:
           cd asv_bench
           git fetch origin $GITHUB_BASE_REF:base $GITHUB_REF:pr
           asv continuous base pr -e
+          asv publish
+      - name: save benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: Benchmarks
+          path: asv_bench/.asv/html/

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -97,11 +97,26 @@ jobs:
       # Load cached venv if cache exists
       # Install dependencies if cache does not exist
       # ======
+      - name: Load cached venv
+        id: cached-poetry-dependencies-dev
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: dev-${{ matrix.python-version }}-${{ matrix.poetry-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
+        if: steps.cached-poetry-dependencies-dev.outputs.cache-hit != 'true'
         run: poetry install --no-interaction -E dev
-      - name: Run ASV benchmarks
+      # ======
+      # Compare benchmarks between master and PR, and fail if any get worse
+      # ======
+
+      - name: Setup ASV
         run: |
           pip install asv
           cd asv_bench
           asv machine --yes
-          asv continuous $GITHUB_BASE_REF $GITHUB_REF --strict -e --python=same 
+      - name: Check regression
+        run: |
+          cd asv_bench
+          git fetch origin $GITHUB_BASE_REF:base $GITHUB_REF:pr
+          asv continuous base pr -e

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -58,3 +58,50 @@ jobs:
       # ======
       - name: Run tests
         run: poetry run pytest
+
+  benchmarks:
+    name: ASV Benchmarks
+    needs: test
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+        poetry-version: ["1.2.1"]
+    steps:
+      # ======
+      # Checkout, set up python
+      # ======
+      - name: Check out
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      # ======
+      # Install and configure poetry
+      # ======
+      - name: Load cached Poetry installation
+        id: cached-poetry
+        uses: actions/cache@v4
+        with:
+          path: ~/.local  # the path depends on the OS
+          key: poetry-${{ matrix.poetry-version }}
+      - name: Install Poetry
+        if: steps.cached-poetry.outputs.cache-hit != 'true'
+        uses: snok/install-poetry@v1
+        with:
+          version: ${{ matrix.poetry-version }}
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+      # ======
+      # Load cached venv if cache exists
+      # Install dependencies if cache does not exist
+      # ======
+      - name: Install dependencies
+        run: poetry install --no-interaction -E dev
+      - name: Run ASV benchmarks
+        run: |
+          pip install asv
+          cd asv_bench
+          asv machine --yes
+          asv continuous $GITHUB_BASE_REF $GITHUB_REF --strict -e --python=same 

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -122,9 +122,3 @@ jobs:
           cd asv_bench
           git fetch origin $GITHUB_BASE_REF:base $GITHUB_REF:pr
           asv continuous base pr -e
-          asv publish
-      - name: save benchmark results
-        uses: actions/upload-artifact@v4
-        with:
-          name: Benchmarks
-          path: asv_bench/.asv/html/

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,11 @@ venv.bak/
 
 # Exploratory work
 playground/
+
+# Unit / Performance Testing #
+##############################
+asv_bench/.asv/env/
+asv_bench/.asv/html/
+asv_bench/.asv/results/
+asv_bench/derivative/
+test-data.xml

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -1,0 +1,14 @@
+{
+    "version": 1,
+    "project": "derivative",
+    "project_url": "https://derivative.readthedocs.io/",
+    "repo": "..",
+    "environment_type": "virtualenv",
+    "env_dir": ".asv/env",
+    "results_dir": ".asv/results",
+    "html_dir": ".asv/html",
+    "show_commit_url": "https://github.com/$OWNER/$REPO/commit/",
+    "build_command": [
+        "python -m build --outdir {build_cache_dir} {build_dir}"
+    ]
+}

--- a/asv_bench/benchmarks/finite_difference_1D.py
+++ b/asv_bench/benchmarks/finite_difference_1D.py
@@ -1,0 +1,31 @@
+# Write the benchmarking functions here.
+# See "Writing benchmarks" in the asv docs for more information.
+
+
+class TimeSuite:
+    """
+    An example benchmark that times the performance of various kinds
+    of iterating over dictionaries in Python.
+    """
+    def setup(self):
+        self.d = {}
+        for x in range(500):
+            self.d[x] = None
+
+    def time_keys(self):
+        for key in self.d.keys():
+            pass
+
+    def time_values(self):
+        for value in self.d.values():
+            pass
+
+    def time_range(self):
+        d = self.d
+        for key in range(500):
+            d[key]
+
+
+class MemSuite:
+    def mem_list(self):
+        return [0] * 256

--- a/asv_bench/benchmarks/finite_difference_1D.py
+++ b/asv_bench/benchmarks/finite_difference_1D.py
@@ -1,29 +1,19 @@
 # Write the benchmarking functions here.
 # See "Writing benchmarks" in the asv docs for more information.
+import numpy as np
+from derivative import FiniteDifference
 
-
-class TimeSuite:
+class FiniteDifferenceBM:
     """
     An example benchmark that times the performance of various kinds
     of iterating over dictionaries in Python.
     """
     def setup(self):
-        self.d = {}
-        for x in range(500):
-            self.d[x] = None
+        self.differentiator = FiniteDifference(k=1)
+        self.t = np.arange(0, 2 * np.pi, .01)
 
-    def time_keys(self):
-        for key in self.d.keys():
-            pass
-
-    def time_values(self):
-        for value in self.d.values():
-            pass
-
-    def time_range(self):
-        d = self.d
-        for key in range(500):
-            d[key]
+    def time_derivative(self):
+        self.differentiator.d(X=self.t, t=self.t, axis=0)
 
 
 class MemSuite:

--- a/asv_bench/benchmarks/finite_difference_1D.py
+++ b/asv_bench/benchmarks/finite_difference_1D.py
@@ -15,7 +15,5 @@ class FiniteDifferenceBM:
     def time_derivative(self):
         self.differentiator.d(X=self.t, t=self.t, axis=0)
 
-
-class MemSuite:
-    def mem_list(self):
-        return [0] * 256
+    def peakmem_derivative(self):
+        self.differentiator.d(X=self.t, t=self.t, axis=0)

--- a/derivative/dlocal.py
+++ b/derivative/dlocal.py
@@ -35,8 +35,6 @@ class FiniteDifference(Derivative):
         return np.sum(res)
 
     def compute(self, t, x, i):
-        import time
-        time.sleep(1e-3)
         dt = t[1] - t[0]
 
         if not self.periodic:

--- a/derivative/dlocal.py
+++ b/derivative/dlocal.py
@@ -35,6 +35,8 @@ class FiniteDifference(Derivative):
         return np.sum(res)
 
     def compute(self, t, x, i):
+        import time
+        time.sleep(1e-3)
         dt = t[1] - t[0]
 
         if not self.periodic:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,12 @@ matplotlib = {version = "^3.2.1", optional = true}
 #pandoc = {version = "^2.2", optional = true}
 
 # dev
+asv = {version = "^0.6", optional = true}
 pytest = {version = "^7", optional = true}
 
 [tool.poetry.extras]
 docs = ["sphinx", "nbsphinx", "ipykernel", "jupyter_client", "matplotlib", "pandoc"]
-dev = ["pytest"]
+dev = ["asv", "pytest"]
 
 [build-system]
 requires = ["poetry-core>=1.1.0"]


### PR DESCRIPTION
Hey Andy, I've added some logging to an experiment and found that some derivative methods can be slow.  This isn't a surprise, but the enterprise solution is to add benchmarking to CI so that we can start quantifying improvements.  This uses Airspeed Velocity (`asv`), the same benchmarking package as pandas.

Like most PRs that deal with CI, this one may have a variety of commits to try to get it working.  I don't know yet how to feed asv previous benchmark results so that it can know performance improvements/regressions.