### PR TITLE
BUG: Loosen importlib metadata dependency version range

### DIFF
--- a/derivative/__version__.py
+++ b/derivative/__version__.py
@@ -1,1 +1,1 @@
-__version__: str = '0.6.2'
+__version__: str = '0.6.3'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ python = "^3.9"
 numpy = "^1.18.3"
 scipy = "^1.4.1"
 scikit-learn = "^1"
-importlib-metadata = "^7.1.0"
+importlib-metadata = ">=7.1.0"
 
 # docs
 sphinx = {version = "^5", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "derivative"
-version = "0.6.2"
+version = "0.6.3"
 description = "Numerical differentiation in python."
 repository = "https://github.com/andgoldschmidt/derivative"
 documentation = "https://derivative.readthedocs.io/"


### PR DESCRIPTION
This package is a backport of part of the core library in 3.10, so is extremely stable.  It will no longer be required in a year, when 3.9 reaches EOL.  In the meantime, it is causing failures of pysindy installs.  See dynamicslab/pysindy#547 and coments on dynamicslab/pysindy#529.  Specifically, colab environments have some requirement for importlib-metadata >=8.0, so people fail to install derivative and pysindy.