### PR TITLE
Upgrade some doc dependencies to allow build

### DIFF
--- a/.github/workflows/pull-docs.yml
+++ b/.github/workflows/pull-docs.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9" ]
-        poetry-version: [ "1.2.1" ]
+        python-version: [ "3.11" ]
+        poetry-version: [ "1.8.3" ]
     steps:
       # ======
       # Checkout, set up python

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,23 +9,15 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
-  jobs:
-    post_create_environment:
-      - pip install poetry==1.2.1
-      - poetry config virtualenvs.create false
-    post_install:
-      - poetry install -E docs
+    python: "3.11"
+
+python:
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+      - docs
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py
-
-# If using Sphinx, optionally build your docs in additional formats such as PDF
-# formats:
-#    - pdf
-
-## Optionally declare the Python requirements required to build your docs
-#python:
-#   install:
-#   - requirements: docs/requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry-core>=1.1.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "derivative"
 version = "0.6.2"
@@ -22,24 +26,21 @@ scikit-learn = "^1"
 importlib-metadata = "^7.1.0"
 
 # docs
-sphinx = {version = "^5", optional = true}
-nbsphinx = {version = "^0.6.1", optional = true}
-ipykernel = {version = "^5.2.1", optional = true}
-jupyter_client = {version = "^6.1.3", optional = true}
+sphinx = {version = "7.2.6", optional = true}
+nbsphinx = {version = "^0.9.5", optional = true}
 matplotlib = {version = "^3.2.1", optional = true}
-#pandoc = {version = "^2.2", optional = true}
+ipython = {version = "^8.0.0, !=8.7.0, !=8.18.1", optional = true}
+ipykernel = {version = "^6.0.0", optional = true}
+
 
 # dev
 asv = {version = "^0.6", optional = true}
-pytest = {version = "^7", optional = true}
+pytest = {version = ">=7", optional = true}
 
 [tool.poetry.extras]
-docs = ["sphinx", "nbsphinx", "ipykernel", "jupyter_client", "matplotlib", "pandoc"]
+docs = ["sphinx", "nbsphinx", "matplotlib", "ipython", "ipykernel"]
 dev = ["asv", "pytest"]
 
-[build-system]
-requires = ["poetry-core>=1.1.0"]
-build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.plugins.'derivative.hyperparam_opt']
 "kalman.default" = "derivative.utils:_default_kalman"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-numpy = "^1.18.3"
+numpy = ">=1.18.3"
 scipy = "^1.4.1"
 scikit-learn = "^1"
 importlib-metadata = "^7.1.0"

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -5,6 +5,11 @@ import pytest
 import numpy as np
 import inspect
 
+if int(np.__version__.split(".")[0]) == 1:
+    from numpy.polynomial.polyutils import RankWarning
+else:
+    from numpy.exceptions import RankWarning
+
 def test_register():
     # Check that every class is registered in methods
     class_list = inspect.getmembers(derivative.dlocal, inspect.isclass)\
@@ -89,7 +94,7 @@ def test_small():
 
     # savitzky_golay - RankWarning: The fit may be poorly conditioned if order >= points in window
     kwargs = {'left': 2, 'right': 2, 'iwindow': True, 'order': 2}
-    with pytest.warns(UserWarning): # numpy.RankWarning is of type UserWarning
+    with pytest.warns(RankWarning):
         assert two.shape == dxdt(two, two, kind='savitzky_golay', **kwargs).shape
     assert three.shape == dxdt(three, three, kind='savitzky_golay', **kwargs).shape
 


### PR DESCRIPTION
This loosens the upper range of some dependencies and upgrades some, making it easier to find matching distributions.  It aims to solve #47, but because I can't repro that, it may be a process.

It also uses configuration to specify the RTD build, rather than commands.  This means it uses pip as the frontend.  LMK if you want me to change it back, or if you want me to move the CI to use pip frontend as well.