### PR TITLE
README corrections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Numerical differentiation methods for noisy time series data in python includes:
     import numpy as np
 
     t = np.linspace(0,2*np.pi,50)
-    x = np.sin(x)
+    x = np.sin(t)
 
     # 1. Finite differences with central differencing using 3 points.
     result1 = dxdt(x, t, kind="finite_difference", k=1)


### PR DESCRIPTION
The readme's demo includes a line `x=np.sin(x)`. This fixes that typo. The code runs once that's corrected. Well, that's not actually true; I had other issues when importing dxdt, but I'll bring that up elsewhere.